### PR TITLE
Add Beta/Bernoulli conjugate prior

### DIFF
--- a/src/OnlineSampling.jl
+++ b/src/OnlineSampling.jl
@@ -19,7 +19,7 @@ using Reexport
 
 include("cond_distr/CondDistr.jl")
 import ..CondDistr as CD
-import ..CondDistr: CdMvNormal
+import ..CondDistr: CdMvNormal, CdBernoulli
 
 include("symb_interface.jl")
 using .SymbInterface

--- a/src/belief_propagation/ops.jl
+++ b/src/belief_propagation/ops.jl
@@ -30,7 +30,7 @@ function dist!(gm::GraphicalModel, node::Initialized)
     return node_dist
 end
 
-function realize!(gm::GraphicalModel, node::Initialized, value::AbstractArray)
+function realize!(gm::GraphicalModel, node::Initialized, value::Union{Number,AbstractArray})
     @assert has_parent(gm, node)
     parent = get_parent(gm, node)
     parent_dist = dist!(gm, parent)
@@ -41,15 +41,20 @@ function dist!(gm::GraphicalModel, node::Union{Marginalized,Realized})
     node.d
 end
 
-observe!(::GraphicalModel, ::Realized, ::AbstractArray) = throw(RealizedObservation())
+observe!(::GraphicalModel, ::Realized, ::Union{Number,AbstractArray}) =
+    throw(RealizedObservation())
 
-function observe!(gm::GraphicalModel, node::Marginalized, value::AbstractArray)
+function observe!(
+    gm::GraphicalModel,
+    node::Marginalized,
+    value::Union{Number,AbstractArray},
+)
     new_node = Realized(node.id, value)
     set!(gm, new_node)
     return logpdf(node.d, value)
 end
 
-function observe!(gm::GraphicalModel, node::Initialized, value::AbstractArray)
+function observe!(gm::GraphicalModel, node::Initialized, value::Union{Number,AbstractArray})
     @assert has_parent(gm, node)
     parent = get_parent(gm, node)
     node_dist, new_dist_parent = realize!(gm, node, value)
@@ -127,7 +132,11 @@ function rand!(gm::GraphicalModel{I}, id::I) where {I}
     return val
 end
 
-function observe!(gm::GraphicalModel{I}, id::I, value::AbstractArray) where {I}
+function observe!(
+    gm::GraphicalModel{I},
+    id::I,
+    value::Union{Number,AbstractArray},
+) where {I}
     @debug "Observe $(gm.nodes[id]) with value $value"
     ll = observe!(gm, gm.nodes[id], value)
     return ll

--- a/src/belief_propagation/structs.jl
+++ b/src/belief_propagation/structs.jl
@@ -10,7 +10,8 @@ struct Marginalized{I<:Integer,F,S,D<:Distribution{F,S}} <: AbstractNode{I,F,S}
     d::D
 end
 
-struct Realized{I<:Integer,F,S,A<:AbstractArray,D<:Distribution{F,S}} <: AbstractNode{I,F,S}
+struct Realized{I<:Integer,F,S,A<:Union{Number,AbstractArray},D<:Distribution{F,S}} <:
+       AbstractNode{I,F,S}
     id::I
     d::D
     val::A

--- a/src/cond_distr/CondDistr.jl
+++ b/src/cond_distr/CondDistr.jl
@@ -9,6 +9,7 @@ using Chain
 include("cd.jl")
 include("linear_gaussian_cd.jl")
 
-export condition, CdMvNormal, ConditionalDistribution, DummyCD, condition_cd, jointdist
+export condition,
+    CdMvNormal, CdBernoulli, ConditionalDistribution, DummyCD, condition_cd, jointdist
 
 end

--- a/src/cond_distr/linear_gaussian_cd.jl
+++ b/src/cond_distr/linear_gaussian_cd.jl
@@ -65,7 +65,7 @@ struct CdNormal{F<:AbstractFloat} <: ConditionalDistribution{Univariate,Continuo
     σ::F
 end
 
-(cd::CdNormal)() = Normal(cd.linear * cd.μ, σ)
+(cd::CdNormal)() = Normal(cd.μ, cd.σ)
 (cd::CdNormal)(parent::AbstractFloat) = Normal(cd.linear * parent + cd.μ, cd.σ)
 (cd::CdNormal)(parent::Normal) =
     Normal(cd.linear * parent.μ + cd.μ, sqrt(cd.linear^2 * parent.σ^2 + cd.σ^2))
@@ -77,4 +77,17 @@ function condition_cd(parent::Normal, child::CdNormal)
     new_linear = cor / (child_d.σ^2)
     new_mean = parent.μ - new_linear * child_d.μ
     return CdNormal(new_linear, new_mean, new_cov)
+end
+
+struct CdBernoulli <: ConditionalDistribution{Univariate,Discrete} end
+
+(cd::CdBernoulli)(parent::AbstractFloat) = Bernoulli(parent)
+(cd::CdBernoulli)(parent::Beta) = Bernoulli(parent.α / (parent.α + parent.β))
+
+function condition(parent::Beta, child::CdBernoulli, child_val::Bool)
+    return Beta(parent.α + child_val, parent.β + (1 - child_val))
+end
+
+function condition_cd(parent::Beta, child::CdBernoulli)
+    return child(parent)
 end

--- a/src/delayed_sampling/ops.jl
+++ b/src/delayed_sampling/ops.jl
@@ -1,4 +1,4 @@
-function realize!(gm::GraphicalModel, node::Marginalized, val::AbstractArray)
+function realize!(gm::GraphicalModel, node::Marginalized, val::Union{Number,AbstractArray})
     # Does renew node
     @chain node begin
         @aside @assert is_terminal(gm, _)
@@ -137,9 +137,14 @@ function retract!(gm::GraphicalModel, node::Marginalized)
     return updated(gm, node)
 end
 
-observe!(::GraphicalModel, ::Realized, ::AbstractArray) = throw(RealizedObservation())
+observe!(::GraphicalModel, ::Realized, ::Union{Number,AbstractArray}) =
+    throw(RealizedObservation())
 
-function observe!(gm::GraphicalModel, node::AbstractNode, value::AbstractArray)
+function observe!(
+    gm::GraphicalModel,
+    node::AbstractNode,
+    value::Union{Number,AbstractArray},
+)
     marginalized_node = dist!(gm, node)
     ll = logpdf(marginalized_node.d, value)
     new_node = realize!(gm, marginalized_node, value)
@@ -191,7 +196,11 @@ function rand!(gm::GraphicalModel{I}, id::I) where {I}
     return val
 end
 
-function observe!(gm::GraphicalModel{I}, id::I, value::AbstractArray) where {I}
+function observe!(
+    gm::GraphicalModel{I},
+    id::I,
+    value::Union{Number,AbstractArray},
+) where {I}
     @debug "Observe $(gm.nodes[id]) with value $value"
     _, ll = observe!(gm, gm.nodes[id], value)
     return ll

--- a/src/delayed_sampling/structs.jl
+++ b/src/delayed_sampling/structs.jl
@@ -20,8 +20,13 @@ struct Marginalized{I<:Integer,F,S,D<:Distribution{F,S},CD<:ConditionalDistribut
 end
 
 # TODO: enforce constraints between T, N and F, S
-struct Realized{I<:Integer,F,S,A<:AbstractArray,CD<:ConditionalDistribution{F,S}} <:
-       AbstractNode{I,F,S}
+struct Realized{
+    I<:Integer,
+    F,
+    S,
+    A<:Union{Number,AbstractArray},
+    CD<:ConditionalDistribution{F,S},
+} <: AbstractNode{I,F,S}
     id::I
     parent_id::Union{I,Nothing}
     parent_child_ref::Union{ListNode{I},Nothing}
@@ -61,5 +66,5 @@ Marginalized(node::Initialized, d::Distribution) = Marginalized(
     d,
 )
 
-Realized(node::AbstractNode, val::AbstractArray) =
+Realized(node::AbstractNode, val::Union{Number,AbstractArray}) =
     Realized(node.id, node.parent_id, node.parent_child_ref, node.children, node.cd, val)

--- a/src/tracked_rv.jl
+++ b/src/tracked_rv.jl
@@ -159,7 +159,8 @@ track_rv(gm::GraphicalModel, d::AbstractMvNormal) = LinearTracker(gm, initialize
 # TODO (api impr): clean the two following lines
 track_rv(gm::GraphicalModel, t::Tuple{CdMvNormal,I}) where {I} =
     LinearTracker(gm, initialize!(gm, t...), t[1]())
-
+track_rv(gm::GraphicalModel, t::Tuple{CdBernoulli,I}) where {I} =
+    LinearTracker(gm, initialize!(gm, t...), t[1]())
 """
     Compute the conditional MvNormal distribution from a LinearTracker
 """

--- a/test/belief_propagation/beta_bernoulli.jl
+++ b/test/belief_propagation/beta_bernoulli.jl
@@ -1,0 +1,29 @@
+using OnlineSampling.BP
+using OnlineSampling.CD
+
+@testset "Observe parent" begin
+    gm = BP.GraphicalModel(Int)
+
+    x = initialize!(gm, Beta(1.0, 1.0))
+    y = initialize!(gm, CdBernoulli(), x)
+    observe!(gm, y, true)
+
+    x_node = gm.nodes[x]
+    y_node = gm.nodes[y]
+
+    @test y_node isa BP.Realized
+    @test y_node.val ≈ true
+    @test x_node isa BP.Marginalized
+    @test x_node.d ≈ Beta(2, 1)
+
+    z = initialize!(gm, CdBernoulli(), x)
+    observe!(gm, z, true)
+
+    x_node = gm.nodes[x]
+    z_node = gm.nodes[z]
+
+    @test y_node isa BP.Realized
+    @test y_node.val ≈ true
+    @test x_node isa BP.Marginalized
+    @test x_node.d ≈ Beta(3, 1)
+end

--- a/test/delayed_sampling/beta_bernoulli.jl
+++ b/test/delayed_sampling/beta_bernoulli.jl
@@ -1,0 +1,38 @@
+using OnlineSampling.DS
+using OnlineSampling.CD
+
+@testset "Observe parent" begin
+    gm = DS.GraphicalModel(Int)
+    @test DS.is_inv_sat(gm)
+
+    x = initialize!(gm, Beta(1.0, 1.0))
+    @test DS.is_inv_sat(gm)
+
+    y = initialize!(gm, CdBernoulli(), x)
+    @test DS.is_inv_sat(gm)
+
+    observe!(gm, y, true)
+    @test DS.is_inv_sat(gm)
+
+    x_node = gm.nodes[x]
+    y_node = gm.nodes[y]
+
+    @test y_node isa DS.Realized
+    @test y_node.val ≈ true
+    @test x_node isa DS.Marginalized
+    @test x_node.d ≈ Beta(2, 1)
+
+    z = initialize!(gm, CdBernoulli(), x)
+    @test DS.is_inv_sat(gm)
+
+    observe!(gm, z, true)
+    @test DS.is_inv_sat(gm)
+
+    x_node = gm.nodes[x]
+    z_node = gm.nodes[z]
+
+    @test y_node isa DS.Realized
+    @test y_node.val ≈ true
+    @test x_node isa DS.Marginalized
+    @test x_node.d ≈ Beta(3, 1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,11 +35,17 @@ include(joinpath(testdir, "online_smc/utils.jl"))
     @testset "DS simple gaussian" begin
         include(joinpath(testdir, "delayed_sampling/simple_gaussian.jl"))
     end
+    @testset "DS beta bernoulli" begin
+        include(joinpath(testdir, "delayed_sampling/beta_bernoulli.jl"))
+    end
     @testset "DS tree of gaussians" begin
         include(joinpath(testdir, "delayed_sampling/tree_gaussian.jl"))
     end
     @testset "BP simple gaussian" begin
         include(joinpath(testdir, "belief_propagation/simple_gaussian.jl"))
+    end
+    @testset "BP beta bernoulli" begin
+        include(joinpath(testdir, "belief_propagation/beta_bernoulli.jl"))
     end
     @testset "SBP simple gaussian" begin
         include(joinpath(testdir, "streaming_belief_propagation/simple_gaussian.jl"))


### PR DESCRIPTION
Trying to add another pair of conjugate distributions.
- Low level interface is working with both DS and BP
- Added tests for DS and BP

I had to update the type signature of operators to accept univariate distributions where the value is a Scalar (not an AbstractArray) using `Union{Number, AbstractArray}`. Maybe there is a more elegant solution?

This is not working with the high-level synchronous constructs.
There is still some work to do to update `tracker_rv.jl` which currently only accept MultiVariate Continuous distributions.