### PR TITLE
bug #44 corrected

### DIFF
--- a/examples/hmm_tree.jl
+++ b/examples/hmm_tree.jl
@@ -11,7 +11,7 @@ const mult = reshape([2.0],1,1)
 
 @node function model()
     @init x0 = rand(MvNormal([0.0], ScalMat(1, 1000.0))) 
-    x0 = rand(MvNormal(@prev(x0), ScalMat(1, speed)))
+    x0 = rand(MvNormal(@prev(x0), ScalMat(1, speed_tree)))
     x1 = rand(MvNormal(x0 + trans1 , ScalMat(1, trans_noise)))
     x2 = rand(MvNormal(mult * x0, ScalMat(1, trans_noise)))
     y1 = rand(MvNormal(x1, ScalMat(1, noise)))
@@ -21,8 +21,8 @@ end
 
 steps = 2
 trajectory = @nodeiter T = steps model()
-obs_y1 = [value(t[end-1]) for t in trajectory]
-obs_y2 = [value(t[end]) for t in trajectory]
+obs_y1 = [t[end-1] for t in trajectory]
+obs_y2 = [t[end] for t in trajectory]
 
 @node function hmm(obs1, obs2)
     x0,x1,x2, y1,y2 = @nodecall model() 

--- a/src/OnlineSampling.jl
+++ b/src/OnlineSampling.jl
@@ -23,6 +23,7 @@ using Distributions:
     Binomial,
     BetaBinomial
 using LinearAlgebra
+using PDMats
 using ConstructionBase
 # For llvm code debugging
 using InteractiveUtils

--- a/src/tracked_rv.jl
+++ b/src/tracked_rv.jl
@@ -173,7 +173,10 @@ value(lt::LinearTracker) = lt.linear * value!(lt.gm, lt.id) + lt.offset
 soft_value(lt::LinearTracker) = lt.linear * rand!(lt.gm, lt.id) + lt.offset
 internal_observe(lt::LinearTracker, obs) =
     observe!(lt.gm, lt.id, lt.linear \ (obs - lt.offset))
-dist(lt::LinearTracker) = dist(lt.gm, lt.id)
+function dist(lt::LinearTracker)
+    node_dist = dist(lt.gm, lt.id)
+    return MvNormal(lt.linear * node_dist.μ + lt.offset, X_A_Xt(node_dist.Σ, lt.linear))
+end
 
 Base.size(lt::LinearTracker) = Base.size(lt.offset)
 

--- a/src/tracked_rv.jl
+++ b/src/tracked_rv.jl
@@ -175,7 +175,7 @@ internal_observe(lt::LinearTracker, obs) =
     observe!(lt.gm, lt.id, lt.linear \ (obs - lt.offset))
 function dist(lt::LinearTracker)
     node_dist = dist(lt.gm, lt.id)
-    return MvNormal(lt.linear * node_dist.μ + lt.offset, X_A_Xt(node_dist.Σ, lt.linear))
+    return lt.linear * node_dist + lt.offset
 end
 
 Base.size(lt::LinearTracker) = Base.size(lt.offset)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,9 @@ include(joinpath(testdir, "online_smc/utils.jl"))
     @testset "SBP beta binomial" begin
         include(joinpath(testdir, "streaming_belief_propagation/beta_binomial.jl"))
     end
+    @testset "SBP tracker" begin
+        include(joinpath(testdir, "streaming_belief_propagation/track_rv.jl"))
+    end
     @testset "online smc" begin
         include(joinpath(testdir, "online_smc/simple_gaussian.jl"))
     end

--- a/test/streaming_belief_propagation/track_rv.jl
+++ b/test/streaming_belief_propagation/track_rv.jl
@@ -1,0 +1,23 @@
+using OnlineSampling.SBP
+using OnlineSampling.CD
+using PDMats
+using OnlineSampling: track_rv
+
+@testset "Tracker SBP" begin
+    mean_vec = [0.0, 1.0]
+    var_vec = ScalMat(2, 1.0)
+    trans_mat  = [1.0 0.0; 1.0 1.0]
+    var_vec2 = X_A_Xt(var_vec, inv(trans_mat))
+
+    gm = SBP.GraphicalModel()
+    x = initialize!(gm, MvNormal(mean_vec, var_vec))
+    y = initialize!(gm, CdMvNormal(trans_mat, mean_vec, var_vec), x)
+
+    gm_trv = SBP.GraphicalModel()
+    lt_x = track_rv(gm_trv, MvNormal(mean_vec, var_vec))
+    lt_z = track_rv(gm_trv, (CdMvNormal(I(2), [0.0,0.0],var_vec2), lt_x.id))
+    lt_y = trans_mat * lt_z + mean_vec
+
+    @test dist(lt_y) ≈ SBP.dist(gm,y)
+    
+end


### PR DESCRIPTION
Correcting bug #44 
Since linear tracker are only used with Gaussian, returning the right distribution as in conditional distribution (but not using CD because there is no noise added i.e. the covariance matrix is zero which is not PD).
Also corrected a bug in an example.
Tests are passing as usual ;-)